### PR TITLE
refactor!: remove duplication in log modes

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,10 @@ import (
 )
 
 func main() {
-	s := server.New(server.DEV)
+	s, err := server.New(server.ModeDev)
+	if err != nil {
+		panic(err)
+	}
 
 	if err := s.Run(); err != nil {
 		panic(err)

--- a/server/handler/error.go
+++ b/server/handler/error.go
@@ -2,9 +2,9 @@ package handler
 
 // wrapError is a utility function to manage any error returned by a handler
 // depending on a context
-// For now, it ignores error on production mode to do not annoying users
+// For now, it ignores error on production mode to not annoy users
 func (h *Handler) wrapError(err error) error {
-	if h.mode == PROD {
+	if h.log.ServerMode.IsProd() {
 		return nil
 	}
 

--- a/server/handler/handler.go
+++ b/server/handler/handler.go
@@ -6,14 +6,6 @@ package handler
 import (
 	"github.com/dagger/daggerlsp/workspace"
 	protocol "github.com/tliron/glsp/protocol_3_16"
-	"github.com/tliron/kutil/logging"
-)
-
-type Mode int
-
-const (
-	DEV Mode = iota
-	PROD
 )
 
 // Handler is the storage for any handler of the server.LSP.
@@ -23,23 +15,20 @@ type Handler struct {
 
 	handler *protocol.Handler
 
-	log logging.Logger
+	log Logger
 
 	lsName string
 
 	lsVersion string
-
-	mode Mode
 }
 
 // New creates a Handler instance that contains all methods supported by
 // the LSP
-func New(lsName, lsVersion string, log logging.Logger, mode Mode) *Handler {
+func New(lsName, lsVersion string, log Logger, mode ServerMode) *Handler {
 	h := &Handler{
 		lsName:    lsName,
 		lsVersion: lsVersion,
-		log:       logging.NewScopeLogger(log, "workspace"),
-		mode:      mode,
+		log:       log,
 	}
 
 	h.handler = &protocol.Handler{

--- a/server/handler/logger.go
+++ b/server/handler/logger.go
@@ -1,0 +1,12 @@
+package handler
+
+import "github.com/tliron/kutil/logging"
+
+type ServerMode interface {
+	IsProd() bool
+}
+
+type Logger struct {
+	logging.Logger
+	ServerMode ServerMode
+}

--- a/server/mode.go
+++ b/server/mode.go
@@ -8,8 +8,5 @@ const (
 )
 
 func (m Mode) IsProd() bool {
-	if m == ModeProd {
-		return true
-	}
-	return false
+	return m == ModeProd
 }

--- a/server/mode.go
+++ b/server/mode.go
@@ -1,0 +1,17 @@
+package server
+
+type Mode int
+
+const (
+	ModeProd Mode = iota
+	ModeDev
+)
+
+func (m Mode) IsProd() bool {
+	switch m {
+	case ModeProd:
+		return true
+	default:
+		return false
+	}
+}

--- a/server/mode.go
+++ b/server/mode.go
@@ -8,10 +8,8 @@ const (
 )
 
 func (m Mode) IsProd() bool {
-	switch m {
-	case ModeProd:
+	if m == ModeProd {
 		return true
-	default:
-		return false
 	}
+	return false
 }

--- a/server/server.go
+++ b/server/server.go
@@ -4,6 +4,8 @@
 package server
 
 import (
+	"errors"
+
 	"github.com/dagger/daggerlsp/server/handler"
 	"github.com/tliron/glsp/server"
 	"github.com/tliron/kutil/logging"
@@ -23,32 +25,49 @@ const (
 	Version = "0.0.1"
 )
 
-type Mode handler.Mode
+type Mode int
 
 const (
-	DEV Mode = iota
-	PROD
+	ModeProd Mode = iota
+	ModeDev
 )
+
+func (m Mode) IsProd() bool {
+	switch m {
+	case ModeProd:
+		return true
+	default:
+		return false
+	}
+}
 
 // New initializes a new language protocol server that contains his logger
 // and his handler
-func New(mode Mode) *LSP {
+func New(mode Mode) (*LSP, error) {
 	// This increases logging verbosity (optional)
 	// logTo := "/tmp/daggerlsp.log"
 	// logging.Configure(2, &logTo)
-	if mode == DEV {
+	switch mode {
+	case ModeDev:
 		logging.Configure(2, nil)
-	} else {
+	case ModeProd:
 		logging.Configure(0, nil)
+	default:
+		return nil, errors.New("unknown logging mode")
 	}
-	log := logging.GetLogger(Name)
 
-	h := handler.New(Name, Version, log, handler.Mode(mode))
+	baseLog := logging.GetLogger(Name)
+	log := handler.Logger{
+		Logger:     logging.NewScopeLogger(baseLog, "workspace"),
+		ServerMode: mode,
+	}
+
+	h := handler.New(Name, Version, log, mode)
 	return &LSP{
 		log:     log,
 		handler: h,
 		server:  server.NewServer(h.Handler(), Name, false),
-	}
+	}, nil
 }
 
 // Run will start the server

--- a/server/server.go
+++ b/server/server.go
@@ -25,22 +25,6 @@ const (
 	Version = "0.0.1"
 )
 
-type Mode int
-
-const (
-	ModeProd Mode = iota
-	ModeDev
-)
-
-func (m Mode) IsProd() bool {
-	switch m {
-	case ModeProd:
-		return true
-	default:
-		return false
-	}
-}
-
 // New initializes a new language protocol server that contains his logger
 // and his handler
 func New(mode Mode) (*LSP, error) {


### PR DESCRIPTION
Just simple improvement to make it more Go idiomatic.
- PascalCase for constants
- prefix with the enum type (since we lack enums in Go :( )
- only use the `server.Mode` instead of `server.Mode` + `handler.Mode`
- break the dependency loop with a `ServerMode` interface

Otherwise, it's confusing on what mode to use.
Also, the light enforcing on enum-like type makes it miss some logic (might not configure the logging accordingly if you use `server.Mode(123)`.